### PR TITLE
DynamicTable: Make the colnames' dtype text again

### DIFF
--- a/common/table.yaml
+++ b/common/table.yaml
@@ -87,7 +87,7 @@ groups:
     of usability.
   attributes:
   - name: colnames
-    dtype: ascii
+    dtype: text
     dims:
     - num_columns
     shape:


### PR DESCRIPTION
In b093942 (fix bugs in schema, 2019-01-09) the dtype was changed from
text to ascii.

This breaks the IPNWB module in Igor Pro as we can only write HDF5
objects with UTF8 encoded names. There is also little reason why in the
21st century we want to only accept ASCII encoded HDF5 object names.

The HDF5 documentation [1] has to say the following

> By default, HDF5 creates object and attribute names with ASCII character
> encoding. An object or attribute creation property list setting is
> required to create object names with UTF-8 characters. This uses the
> function H5Pset_char_encoding, which sets the character encoding used
> for object and attribute names.

and looking at [2] reveals that the function H5Pset_char_encoding was
introduced with HDF5 1.8.

h5py supports UTF8 as well according to [3].

Therefore we can safely switch it back.

[1]: https://portal.hdfgroup.org/display/HDF5/Using+UTF-8++Encoding+in+HDF5+Applications
[2]: https://portal.hdfgroup.org/display/HDF5/H5P_SET_CHAR_ENCODING
[3]: https://docs.h5py.org/en/stable/strings.html#object-names

Close #4.