### PR TITLE
Clarify paths in templates/software process, fix formatting

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,10 @@
 ## Checklist
 
 - If the current schema version on "master" is a public release:
-  - [ ] Update the version string in `conf.py` and `namespace.yaml` to the next version with the suffix "-alpha"
+  - [ ] Update the version string in `docs/source/conf.py` and `common/namespace.yaml` to the next version with the
+    suffix "-alpha"
   - [ ] Add a new section in the release notes for the new version with the date "Upcoming"
 
-- [ ] Add release notes for the PR
+- [ ] Add release notes for the PR to `docs/source/format_release_notes.rst`
 
 See https://hdmf-common-schema.readthedocs.io/en/latest/software_process.html for more details.

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -2,16 +2,17 @@
 
 Before merging:
 - [ ] Update requirements versions as needed
-- [ ] Update legal file dates and information in ``Legal.txt``, ``license.txt``, ``README.rst``, ``conf.py``, and any other locations as needed
+- [ ] Update legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`,
+  and any other locations as needed
 - [ ] Update README as needed
-- [ ] Update the version string in ``conf.py`` and ``namespace.yaml`` (remove "-alpha" suffix)
-- [ ] Update ``conf.py`` as needed
-- [ ] Update release notes (set release date) and relevant docs
-- [ ] Test docs locally (``make fulldoc``)
-- [ ] Push changes to a new PR and make sure all PRs to be included in this release have been merged
+- [ ] Update the version string in `docs/source/conf.py` and `common/namespace.yaml` (remove "-alpha" suffix)
+- [ ] Update `docs/source/conf.py` as needed
+- [ ] Update release notes (set release date) in `docs/source/format_release_notes.rst` and any other docs as needed
+- [ ] Test docs locally (`make fulldoc`)
+- [ ] Push changes to this PR and make sure all PRs to be included in this release have been merged
 - [ ] Point the HDMF submodule to this branch in the HDMF branch corresponding to this schema version and run HDMF tests
-- [ ] Check that the readthedocs build for this PR succeeds (build latest to pull the new branch, then activate and build docs for new branch):
-  https://readthedocs.org/projects/hdmf-common-schema/builds/
+- [ ] Check that the readthedocs build for this PR succeeds (build latest to pull the new branch, then activate and
+  build docs for new branch): https://readthedocs.org/projects/hdmf-common-schema/builds/
 
 After merging:
 1. Create release on GitHub releases page with release notes

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,7 @@ def run_doc_autogen(_):
 
 def setup(app):
    app.connect('builder-inited', run_doc_autogen)
-   app.add_stylesheet("theme_overrides.css")  # overrides for wide tables in RTD theme
+   app.add_css_file("theme_overrides.css")  # overrides for wide tables in RTD theme
 
 
 # -- ext settings -----------------------------------------------------

--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -6,12 +6,13 @@ Actions to take on each PR that does not prepare the schema for a public release
 
 If the current schema version on "master" is a public release, then:
 
-1. Update the version string in ``conf.py`` and ``namespace.yaml`` to the next version with the suffix "-alpha"
+1. Update the version string in ``docs/source/conf.py`` and ``common/namespace.yaml`` to the next version with the
+   suffix "-alpha"
 2. Add a new section in the release notes for the new version with the date "Upcoming"
 
 Always:
 
-1. Add release notes for the PR
+1. Add release notes for the PR to ``docs/source/format_release_notes.rst``
 
 Merging PRs and Making Releases
 ===============================
@@ -25,9 +26,9 @@ hdmf-common-schema. All schema that use hdmf-common-schema as a submodule MUST a
 The default branch of hdmf-common-schema is "master". The "master" branch holds the bleeding edge version of
 the hdmf-common schema specification.
 
-PRs should be made to "master". Every PR should include an update to ``/docs/source/format_release_notes.rst``.
+PRs should be made to "master". Every PR should include an update to ``docs/source/format_release_notes.rst``.
 If the current version is a public release, then the PR should also update the version of the schema in two places:
-``/docs/source/conf.py`` and ``/common/namespace.yaml``. The new version should be the next bugfix/minor/major version
+``docs/source/conf.py`` and ``common/namespace.yaml``. The new version should be the next bugfix/minor/major version
 of the schema with the suffix "-alpha". For example, if the current schema on "master" has version "2.2.0",
 then a PR implementing a bug fix should update the schema version from "2.2.0" to "2.2.1-alpha". Appending the "-alpha"
 suffix ensures that any person or API accessing the default "master" branch of the repo containing an internal release
@@ -58,12 +59,12 @@ Making a Release Checklist
 Before merging:
 
 1. Update requirements versions as needed
-2. Update legal file dates and information in ``Legal.txt``, ``license.txt``, ``README.rst``, ``conf.py``, and any
-   other locations as needed
+2. Update legal file dates and information in ``Legal.txt``, ``license.txt``, ``README.rst``, ``docs/source/conf.py``,
+   and any other locations as needed
 3. Update README as needed
-4. Update the version string in ``conf.py`` and ``namespace.yaml`` (remove "-alpha" suffix)
-5. Update ``conf.py`` as needed
-6. Update release notes (set release date) and relevant docs
+4. Update the version string in ``docs/source/conf.py`` and ``common/namespace.yaml`` (remove "-alpha" suffix)
+5. Update ``docs/source/conf.py`` as needed
+6. Update release notes (set release date) in ``docs/source/format_release_notes.rst`` and any other docs as needed
 7. Test docs locally (``make fulldoc``)
 8. Push changes to a new PR and make sure all PRs to be included in this release have been merged. Add
    ``?template=release.md`` to the PR URL to auto-populate the PR with this checklist.


### PR DESCRIPTION
From @ajtritt 's suggestions, this PRs adds paths to the filenames in the PR templates and fixes formatting. Also fixes a minor sphinx warning.

## Checklist

- If the current schema version on "master" is a public release:
  - [ ] Update the version string in `conf.py` and `namespace.yaml` to the next version with the suffix "-alpha"
  - [ ] Add a new section in the release notes for the new version with the date "Upcoming"

- [x] Add release notes for the PR **- release notes for the software process have already been added**

See https://hdmf-common-schema.readthedocs.io/en/latest/software_process.html for more details.
