### PR TITLE
Fix links in software process and remove unnecessary step

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,8 @@
-## Checklist
+## PR Checklist
 
-- If the current schema version on "master" is a public release:
-  - [ ] Update the version string in `docs/source/conf.py` and `common/namespace.yaml` to the next version with the
-    suffix "-alpha"
-  - [ ] Add a new section in the release notes for the new version with the date "Upcoming"
-
+<!-- If the current schema version already ends in "-alpha", then delete the first two items: -->
+- [ ] Update the version string in `docs/source/conf.py` and `common/namespace.yaml` to the next version with the suffix "-alpha"
+- [ ] Add a new section in the release notes for the new version with the date "Upcoming"
 - [ ] Add release notes for the PR to `docs/source/format_release_notes.rst`
 
-See https://hdmf-common-schema.readthedocs.io/en/latest/software_process.html for more details.
+<!-- See https://hdmf-common-schema.readthedocs.io/en/latest/software_process.html for more details. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+## Summary of changes
+
+- ...
+
 ## PR Checklist
 
 <!-- If the current schema version already ends in "-alpha", then delete the first two items: -->

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -4,7 +4,7 @@ Before merging:
 - [ ] Update requirements versions as needed
 - [ ] Update legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`,
   and any other locations as needed
-- [ ] Update README as needed
+- [ ] Update `README.md` as needed
 - [ ] Update the version string in `docs/source/conf.py` and `common/namespace.yaml` (remove "-alpha" suffix)
 - [ ] Update `docs/source/conf.py` as needed
 - [ ] Update release notes (set release date) in `docs/source/format_release_notes.rst` and any other docs as needed
@@ -15,7 +15,7 @@ Before merging:
   build docs for new branch): https://readthedocs.org/projects/hdmf-common-schema/builds/
 
 After merging:
-1. Create release on GitHub releases page with release notes
+1. Create release on [GitHub releases page](https://github.com/hdmf-dev/hdmf-common-schema/releases) with release notes
 2. Check that the readthedocs "latest" and "stable" builds run and succeed
 
 See https://hdmf-common-schema.readthedocs.io/en/latest/software_process.html for more details.

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,6 +1,6 @@
-# Prepare a release
+Prepare for release of hdmf-common-schema [version]
 
-Before merging:
+### Before merging:
 - [ ] Update requirements versions as needed
 - [ ] Update legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`,
   and any other locations as needed
@@ -14,7 +14,7 @@ Before merging:
 - [ ] Check that the readthedocs build for this PR succeeds (build latest to pull the new branch, then activate and
   build docs for new branch): https://readthedocs.org/projects/hdmf-common-schema/builds/
 
-After merging:
+### After merging:
 1. Create release on [GitHub releases page](https://github.com/hdmf-dev/hdmf-common-schema/releases) with release notes
 2. Check that the readthedocs "latest" and "stable" builds run and succeed
 

--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -39,12 +39,7 @@ of the schema receives the schema with a version string that is distinct from pu
 current schema on "master" is already an internal release, then the version string does not need to be updated unless
 the PR requires an upgrade in the version (e.g., from bugfix to minor).
 
-Before merging a PR on hdmf-common-schema, developers should test their changes locally with the latest version of HDMF
-to ensure compatibility. If changes are required in HDMF in order for the changes in hdmf-common-schema to work, then
-the changes in HDMF should be implemented and tested locally *before* merging the PR in hdmf-common-schema. This
-workflow ensures that changes in HDMF can be implemented and no further changes to the schema are required.
-
-HDMF should contain a branch and PR that tracks and is compatible with the "master" branch of hdmf-common-schema. Before
+HDMF should contain a branch and PR that tracks the "master" branch of hdmf-common-schema. Before
 a public release of hdmf-common-schema is made, this HDMF branch should be checked to ensure that when the new release
 is made, the branch can be merged without issue.
 

--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -2,7 +2,7 @@ Making a Pull Request
 =====================
 
 Actions to take on each PR that does not prepare the schema for a public release
-(this is also in ``.github/PULL_REQUEST_TEMPLATE.md``):
+(this is also in the `GitHub PR template`_):
 
 If the current schema version on "master" is a public release, then:
 
@@ -14,6 +14,9 @@ Always:
 
 1. Add release notes for the PR to ``docs/source/format_release_notes.rst``
 
+.. _`GitHub PR template`: https://github.com/hdmf-dev/hdmf-common-schema/blob/master/.github/PULL_REQUEST_TEMPLATE.md
+
+
 Merging PRs and Making Releases
 ===============================
 
@@ -23,8 +26,8 @@ hdmf-common-schema. All schema that use hdmf-common-schema as a submodule MUST a
 
 **Internal release**: a state of the schema "master" branch where the version string ends with "-alpha".
 
-The default branch of hdmf-common-schema is "master". The "master" branch holds the bleeding edge version of
-the hdmf-common schema specification.
+The default branch of hdmf-common-schema is "master". **The "master" branch holds the bleeding edge version of
+the hdmf-common schema specification.**
 
 PRs should be made to "master". Every PR should include an update to ``docs/source/format_release_notes.rst``.
 If the current version is a public release, then the PR should also update the version of the schema in two places:
@@ -77,6 +80,8 @@ After merging:
 1. Create release on GitHub releases page with release notes
 2. Check that the readthedocs "latest" and "stable" builds run and succeed
 
-This is also in ``.github/PULL_REQUEST_TEMPLATE/release-pr.md``.
+This checklist can also be found in the `GitHub release PR template`_.
 
 The time between merging this PR and creating a new public release should be minimized.
+
+.. _`GitHub release PR template`: https://github.com/hdmf-dev/hdmf-common-schema/blob/master/.github/PULL_REQUEST_TEMPLATE/release.md

--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -59,7 +59,7 @@ Before merging:
 1. Update requirements versions as needed
 2. Update legal file dates and information in ``Legal.txt``, ``license.txt``, ``README.rst``, ``docs/source/conf.py``,
    and any other locations as needed
-3. Update README as needed
+3. Update ``README.md`` as needed
 4. Update the version string in ``docs/source/conf.py`` and ``common/namespace.yaml`` (remove "-alpha" suffix)
 5. Update ``docs/source/conf.py`` as needed
 6. Update release notes (set release date) in ``docs/source/format_release_notes.rst`` and any other docs as needed


### PR DESCRIPTION
## Summary of changes

- Fix links in software process docs
- Remove step in software process that says to test and implement changes in an HDMF branch before merging the PR. This is unnecessarily tedious. If an error exists in the schema, then another PR can be made to fix it before the public release.
- Clean up software process text and PR template

## PR Checklist

<!-- If the current schema version already ends in "-alpha", then delete the first two items: -->
- [x] Add release notes for the PR to `docs/source/format_release_notes.rst` 
  **A pending release note already exists for the software process docs**

<!-- See https://hdmf-common-schema.readthedocs.io/en/latest/software_process.html for more details. -->
