### PR TITLE
Add data_type_inc Container to CSRMatrix

### DIFF
--- a/common/namespace.yaml
+++ b/common/namespace.yaml
@@ -22,4 +22,4 @@ namespaces:
   - doc: data types for different types of sparse matrices
     source: sparse.yaml
     title: Sparse data types
-  version: 1.2.0
+  version: 1.2.1-alpha

--- a/common/sparse.yaml
+++ b/common/sparse.yaml
@@ -1,5 +1,6 @@
 groups:
 - data_type_def: CSRMatrix
+  data_type_inc: Container
   doc: a compressed sparse row matrix
   attributes:
   - name: shape

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,7 +83,7 @@ copyright = u'2019-2020, The Regents of the University of California, through La
 # built documents.
 #
 # The short X.Y version.
-version = 'v1.2.0'
+version = 'v1.2.1-alpha'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/source/format_release_notes.rst
+++ b/docs/source/format_release_notes.rst
@@ -1,7 +1,7 @@
 hdmf-common Release Notes
 =========================
 
-1.2.1 (July 10, 2020)
+1.2.1 (Upcoming)
 ------------------------
 - Fix missing data_type_inc for ``CSRMatrix``. It now has ``data_type_inc: Container``.
 

--- a/docs/source/format_release_notes.rst
+++ b/docs/source/format_release_notes.rst
@@ -1,6 +1,10 @@
 hdmf-common Release Notes
 =========================
 
+1.2.1 (July 10, 2020)
+------------------------
+- Fix missing data_type_inc for ``CSRMatrix``. It now has ``data_type_inc: Container``.
+
 1.2.0 (July 10, 2020)
 ------------------------
 


### PR DESCRIPTION
## Summary of changes

- All types that are not `Container` or `Data` should include `Container` or `Data`. The `CSRMatrix` type is defined without an include and should be updated to include `Container`. The HDMF API already has the `CSRMatrix` subclassing `Container`.

## PR Checklist

<!-- If the current schema version already ends in "-alpha", then delete the first two items: -->
- [x] Update the version string in `docs/source/conf.py` and `common/namespace.yaml` to the next version with the suffix "-alpha"
- [x] Add a new section in the release notes for the new version with the date "Upcoming"
- [x] Add release notes for the PR to `docs/source/format_release_notes.rst`

<!-- See https://hdmf-common-schema.readthedocs.io/en/latest/software_process.html for more details. -->
