### PR TITLE
add SimpleMultiContainer

### DIFF
--- a/common/base.yaml
+++ b/common/base.yaml
@@ -7,3 +7,15 @@ groups:
 - data_type_def: Container
   doc: An abstract data type for a group storing collections of data and
     metadata. Base type for all data and metadata containers.
+
+- data_type_def: SimpleMultiContainer
+  data_type_inc: Container
+  doc: A simple Container for holding onto multiple containers
+  datasets:
+  - data_type_inc: Data
+    quantity: '*'
+    doc: Data objects held within this SimpleMultiContainer
+  groups:
+  - data_type_inc: Container
+    quantity: '*'
+    doc: Container objects held within this SimpleMultiContainer

--- a/docs/source/format_release_notes.rst
+++ b/docs/source/format_release_notes.rst
@@ -6,6 +6,7 @@ hdmf-common Release Notes
 
 - Fix missing data_type_inc for ``CSRMatrix``. It now has ``data_type_inc: Container``.
 - Add ``hdmf-schema-language`` comment at the top of each yaml file.
+- Add ``SimpleMultiContainer``, a Container for storing other Container and Data objects together
 
 1.2.0 (July 10, 2020)
 ------------------------


### PR DESCRIPTION
## Summary of changes

- add SimpleMultiContainer, a Container for storing Container and Data objects together

## PR Checklist

<!-- If the current schema version already ends in "-alpha", then delete the first two items: -->
- [x] Update the version string in `docs/source/conf.py` and `common/namespace.yaml` to the next version with the suffix "-alpha"
- [x] Add a new section in the release notes for the new version with the date "Upcoming"
- [x] Add release notes for the PR to `docs/source/format_release_notes.rst`

<!-- See https://hdmf-common-schema.readthedocs.io/en/latest/software_process.html for more details. -->
