### PR TITLE
Update docs and version strings for version 1.2.1

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -8,9 +8,7 @@ Prepare for release of hdmf-common-schema [version]
 - [ ] Update the version string in `docs/source/conf.py` and `common/namespace.yaml` (remove "-alpha" suffix)
 - [ ] Update `docs/source/conf.py` as needed
 - [ ] Update release notes (set release date) in `docs/source/format_release_notes.rst` and any other docs as needed
-- [ ] Test docs locally (`make fulldoc`). Note: if the schema has been changed, then the local copy of HDMF must contain
-  the latest changes in hdmf-common-schema in the git submodule in order for the schema changes to be reflected in the
-  docs.
+- [ ] Test docs locally (`cd docs; make fulldoc`).
 - [ ] Push changes to this PR and make sure all PRs to be included in this release have been merged
 - [ ] Point the HDMF submodule to this branch in the HDMF branch corresponding to this schema version and run HDMF tests
 - [ ] Check that the readthedocs build for this PR succeeds (build latest to pull the new branch, then activate and
@@ -22,9 +20,6 @@ Prepare for release of hdmf-common-schema [version]
 2. On the [GitHub tags page](https://github.com/hdmf-dev/hdmf-common-schema/tags) page, click "Create release" to
    create a release from the new tag. Copy and paste the release notes into the release message and update the title
    to the version string.
-3. Check that the readthedocs "latest" and "stable" builds run and succeed
-4. A new version of HDMF should be released that uses the latest schema release and the schema readthedocs should be
-   rebuilt. Then schema changes will be reflected in the docs. This is due to a dependency between the docs and the
-   API.
+3. Check that the readthedocs "latest" and "stable" builds run and succeed.
 
 See https://hdmf-common-schema.readthedocs.io/en/latest/software_process.html for more details.

--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ The schema also provides the following base data structures:
 
 - **Data :** An abstract data type for a dataset
 - **Container :** An abstract data type for a generic container storing collections of data and metadata
+- **SimpleMultiContainer :** A simple container that holds multiple containers

--- a/common/namespace.yaml
+++ b/common/namespace.yaml
@@ -23,4 +23,4 @@ namespaces:
   - doc: data types for different types of sparse matrices
     source: sparse.yaml
     title: Sparse data types
-  version: 1.2.1-alpha
+  version: 1.2.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,7 +83,7 @@ copyright = u'2019-2020, The Regents of the University of California, through La
 # built documents.
 #
 # The short X.Y version.
-version = 'v1.2.1-alpha'
+version = 'v1.2.1'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/source/conf_doc_autogen.py
+++ b/docs/source/conf_doc_autogen.py
@@ -83,7 +83,7 @@ spec_add_latex_clearpage_after_ndt_sections = True
 spec_resolve_type_inc = False
 
 # Default type map to be used. This is the type map where dependent namespaces are stored.
-spec_default_type_map = hdmf.common.get_type_map()
+spec_default_type_map = hdmf.build.TypeMap(hdmf.spec.NamespaceCatalog())
 
 # Default specification classes for groups datasets and namespaces.
 spec_group_spec_cls = hdmf.spec.GroupSpec

--- a/docs/source/format_release_notes.rst
+++ b/docs/source/format_release_notes.rst
@@ -1,7 +1,7 @@
 hdmf-common Release Notes
 =========================
 
-1.2.1 (Upcoming)
+1.2.1 (November 4, 2020)
 ------------------------
 
 - Update software process documentation for maintainers.

--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -63,9 +63,7 @@ Before merging:
 4. Update the version string in ``docs/source/conf.py`` and ``common/namespace.yaml`` (remove "-alpha" suffix)
 5. Update ``docs/source/conf.py`` as needed
 6. Update release notes (set release date) in ``docs/source/format_release_notes.rst`` and any other docs as needed
-7. Test docs locally (``make fulldoc``). Note: if the schema has been changed, then the local copy of HDMF must contain
-   the latest changes in hdmf-common-schema in the git submodule in order for the schema changes to be reflected in the
-   docs.
+7. Test docs locally (``cd docs; make fulldoc``).
 8. Push changes to a new PR and make sure all PRs to be included in this release have been merged. Add
    ``?template=release.md`` to the PR URL to auto-populate the PR with this checklist.
 9. Point the HDMF submodule to this branch in the HDMF branch corresponding to this schema version and run HDMF tests
@@ -78,10 +76,7 @@ After merging:
    release notes into the tag message, and run ``git push --tags``.
 2. On the `GitHub tags`_ page, click "Create release" to create a release from the new tag. Copy and paste the release
    notes into the release message and update the title to the version string.
-3. Check that the readthedocs "latest" and "stable" builds run and succeed
-4. A new version of HDMF should be released that uses the latest schema release and the schema readthedocs should be
-   rebuilt. Then schema changes will be reflected in the docs. This is due to a dependency between the docs and the
-   API.
+3. Check that the readthedocs "latest" and "stable" builds run and succeed.
 
 This checklist can also be found in the `GitHub release PR template`_.
 


### PR DESCRIPTION
Prepare for release of hdmf-common-schema 1.2.1 on November 4, 2020.

~~Pending merge of https://github.com/hdmf-dev/hdmf-common-schema/pull/41~~
- [x] Update this branch

### Before merging:
- [x] Update requirements versions as needed
- [x] Update legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`,
  and any other locations as needed
- [x] Update `README.md` as needed
- [x] Update the version string in `docs/source/conf.py` and `common/namespace.yaml` (remove "-alpha" suffix)
- [x] Update `docs/source/conf.py` as needed
- [x] Update release notes (set release date) in `docs/source/format_release_notes.rst` and any other docs as needed
- [x] Test docs locally (`make fulldoc`). 
- [x] Push changes to this PR and make sure all PRs to be included in this release have been merged
- [x] Point the HDMF submodule to this branch in the HDMF branch corresponding to this schema version and run HDMF tests
- [x] Check that the readthedocs build for this PR succeeds (build latest to pull the new branch, then activate and
  build docs for new branch): https://readthedocs.org/projects/hdmf-common-schema/builds/

### After merging:
1. Create a new git tag. Pull the latest master branch locally, run `git tag [version] --sign`, copy and paste the
   release notes into the tag message, and run `git push --tags`.
2. On the [GitHub tags page](https://github.com/hdmf-dev/hdmf-common-schema/tags) page, click "Create release" to
   create a release from the new tag. Copy and paste the release notes into the release message and update the title
   to the version string.
3. Check that the readthedocs "latest" and "stable" builds run and succeed

See https://hdmf-common-schema.readthedocs.io/en/latest/software_process.html for more details.
