### PR TITLE
Improve CSRMatrix docs, change dtypes int to uint

### DIFF
--- a/common/namespace.yaml
+++ b/common/namespace.yaml
@@ -26,4 +26,4 @@ namespaces:
   - doc: data types for storing references to web accessible resources
     source: resources.yaml
     title: Resource reference data types
-  version: 1.2.2-alpha
+  version: 1.3.0-alpha

--- a/common/sparse.yaml
+++ b/common/sparse.yaml
@@ -2,8 +2,8 @@
 groups:
 - data_type_def: CSRMatrix
   data_type_inc: Container
-  doc: A compressed sparse row matrix. Data are stored in the standard CSR format, where column indices for row i are
-    stored in indices[indptr[i]:indptr[i+1]] and their corresponding values are stored in data[indptr[i]:indptr[i+1]].
+  doc: 'A compressed sparse row matrix. Data are stored in the standard CSR format, where column indices for row i are
+    stored in indices[indptr[i]:indptr[i+1]] and their corresponding values are stored in data[indptr[i]:indptr[i+1]].'
   attributes:
   - name: shape
     dtype: uint

--- a/common/sparse.yaml
+++ b/common/sparse.yaml
@@ -2,25 +2,34 @@
 groups:
 - data_type_def: CSRMatrix
   data_type_inc: Container
-  doc: a compressed sparse row matrix
+  doc: A compressed sparse row matrix. Data are stored in the standard CSR format, where column indices for row i are
+    stored in indices[indptr[i]:indptr[i+1]] and their corresponding values are stored in data[indptr[i]:indptr[i+1]].
   attributes:
   - name: shape
-    dtype: int
+    dtype: uint
+    dims:
+    - number of rows, number of columns
     shape:
     - 2
-    doc: the shape of this sparse matrix
+    doc: The shape (number of rows, number of columns) of this sparse matrix.
   datasets:
   - name: indices
-    dtype: int
+    dtype: uint
+    dims:
+    - number of non-zero values
     shape:
     - null
-    doc: column indices
+    doc: The column indices.
   - name: indptr
-    dtype: int
+    dtype: uint
+    dims:
+    - number of rows in the matrix + 1
     shape:
     - null
-    doc: index pointer
+    doc: The row index pointer.
   - name: data
+    dims:
+    - number of non-zero values
     shape:
     - null
-    doc: values in the matrix
+    doc: The non-zero values in the matrix.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,7 +83,7 @@ copyright = u'2019-2020, The Regents of the University of California, through La
 # built documents.
 #
 # The short X.Y version.
-version = 'v1.2.1'
+version = 'v1.3.0-alpha'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/source/format_release_notes.rst
+++ b/docs/source/format_release_notes.rst
@@ -1,6 +1,13 @@
 hdmf-common Release Notes
 =========================
 
+1.3.0 (Upcoming)
+-------------------------
+
+- Add data type ``ExternalResources`` for storing ontology information / external resource references.
+- Changed dtype for datasets within ``CSRMatrix`` from 'int' to 'uint'. Negative values do not make sense for these
+  datasets.
+
 1.2.1 (November 4, 2020)
 ------------------------
 


### PR DESCRIPTION
## Summary of changes

- Negative values for `CSRMatrix/shape`, `CSRMatrix/indices`, and `CSRMatrix/indptr` do not make sense. Therefore, the `dtype` of these datasets should be changed from 'int' to 'uint'.
- Improve docs for `CSRMatrix`

## PR checklist for schema changes

<!-- If the current schema version already ends in "-alpha", then delete the first two items: -->
- [x] Update the version string in `docs/source/conf.py` and `common/namespace.yaml` to the next version with the suffix "-alpha"
- [x] Add a new section in the release notes for the new version with the date "Upcoming"
- [x] Add release notes for the PR to `docs/source/format_release_notes.rst`

<!-- See https://hdmf-common-schema.readthedocs.io/en/latest/software_process.html for more details. -->
