### PR TITLE
Update legal, release notes, version to 1.4.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -2,7 +2,7 @@ Prepare for release of hdmf-common-schema [version]
 
 ### Before merging:
 - [ ] Update requirements versions as needed
-- [ ] Update legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`,
+- [ ] Update legal file dates and information in `Legal.txt`, `license.txt`, `README.md`, `docs/source/conf.py`,
   and any other locations as needed
 - [ ] Update `README.md` as needed
 - [ ] Update the version string in `docs/source/conf.py` and `common/namespace.yaml` (remove "-alpha" suffix)

--- a/Legal.txt
+++ b/Legal.txt
@@ -1,4 +1,4 @@
-“hdmf-common-schema” Copyright (c) 2019-2020, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
+“hdmf-common-schema” Copyright (c) 2019-2021, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
 
 If you have questions about your rights to use or distribute this software, please contact Berkeley Lab's Innovation & Partnerships Office at IPO@lbl.gov.
 

--- a/common/namespace.yaml
+++ b/common/namespace.yaml
@@ -23,7 +23,7 @@ namespaces:
   - doc: data types for different types of sparse matrices
     source: sparse.yaml
     title: Sparse data types
-  version: 1.4.0-alpha
+  version: 1.4.0
 
 - name: hdmf-experimental
   doc: Experimental data structures provided by HDMF. These are not guaranteed to be available in the future

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,14 +76,14 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'HDMF-common Specification'
-copyright = u'2019-2020, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.'
+copyright = u'2019-2021, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
 # The short X.Y version.
-version = 'v1.4.0-alpha'
+version = 'v1.4.0'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/source/format_release_notes.rst
+++ b/docs/source/format_release_notes.rst
@@ -1,19 +1,29 @@
 hdmf-common Release Notes
 =========================
 
-1.4.0-alpha (March 16, 2021)
+1.4.0 (March 25, 2021)
 -------------------------
 
+Summary: In 1.4.0, the HDMF-experimental namespace was added, which includes the ``ExternalResources`` and ``EnumData``
+data types. Schema in the HDMF-experimental namespace are experimental and subject to breaking changes at any time.
+``ExternalResources`` was changed to support storing both names and URIs for resources. The ``VocabData`` data type was
+replaced by ``EnumData`` to provide more flexible support for data from a set of fixed values.
 
-- Add ``EnumData`` for storing data that comes from a set of fixed values. This replaces ``VocabData``.
-- Remove ``VocabData``.
-- Rename the "resources" table in ``ExternalResources`` to "entities".
-- Create a new "resources" table to store the name and URI of the ontology / external resource used by the "entities" table in ``ExternalResources``.
-- Rename fields in ``ExternalResources``.
-- Add "EntitiesTable", a Table to replace the functionality of "ResourcesTable" in "ExternalResources"
-- Changed "ResourcesTable" to store the name and uri of the ontology / external resource used by "entities" in "ExternalResources".
-- Add HDMF-experimental
-- Move ``ExternalResources`` to HDMF-experimental
+- Added ``EnumData`` for storing data that comes from a set of fixed values. This replaces ``VocabData`` which could
+  hold only string values. Also, ``VocabData` could hold only a limited number of elements (~64k) when used with the
+  HDF5 storage backend. ``EnumData`` gets around these restrictions by using an untyped dataset (VectorData) instead of
+  a string attribute to hold the enumerated values.
+- Removed ``VocabData``.
+- Renamed the "resources" table in ``ExternalResources`` to "entities".
+- Created a new "resources" table to store the name and URI of the ontology / external resource used by the "entities"
+  table in ``ExternalResources``.
+- Renamed fields in ``ExternalResources``.
+- Added "entities" dataset to ``ExternalResources``. This is a row-based table dataset to replace the functionality of
+  the "resources" dataset in ``ExternalResources``.
+- Changed the "resources" dataset in ``ExternalResources`` to store the name and URI of the ontology / external
+  resource used by the "entities" dataset in ``ExternalResources``.
+- Added HDMF-experimental namespace.
+- Moved ``ExternalResources`` and ``EnumData`` to HDMF-experimental.
 
 1.3.0 (December 2, 2020)
 -------------------------

--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -60,7 +60,7 @@ Making a Release Checklist
 Before merging:
 
 1. Update requirements versions as needed
-2. Update legal file dates and information in ``Legal.txt``, ``license.txt``, ``README.rst``, ``docs/source/conf.py``,
+2. Update legal file dates and information in ``Legal.txt``, ``license.txt``, ``README.md``, ``docs/source/conf.py``,
    and any other locations as needed
 3. Update ``README.md`` as needed
 4. Update the version string in ``docs/source/conf.py`` and ``common/namespace.yaml`` (remove "-alpha" suffix)

--- a/license.txt
+++ b/license.txt
@@ -1,4 +1,4 @@
-“hdmf-common-schema” Copyright (c) 2019-2020, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
+“hdmf-common-schema” Copyright (c) 2019-2021, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 


### PR DESCRIPTION
Prepare for release of hdmf-common-schema 1.4.0

- Updated legal years to include 2021
- Updated release notes
- Updated version to 1.4.0
- Minor updates to doc and GitHub PR template

NOTE: because of how HDMF-docutils is currently structured, only the HDMF-common namespace will be loaded and documented on readthedocs. The HDMF-experimental namespace is not loaded and documented. 

### Before merging:
- [x] Update requirements versions as needed
- [x] Update legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`,
  and any other locations as needed
- [x] Update `README.md` as needed
- [x] Update the version string in `docs/source/conf.py` and `common/namespace.yaml` (remove "-alpha" suffix)
- [x] Update `docs/source/conf.py` as needed
- [x] Update release notes (set release date) in `docs/source/format_release_notes.rst` and any other docs as needed
- [x] Test docs locally (`cd docs; make fulldoc`)
- [x] Push changes to this PR and make sure all PRs to be included in this release have been merged
- [ ] Point the HDMF submodule to this branch in the HDMF branch corresponding to this schema version and check
  that HDMF tests succeed
- [ ] Check that the readthedocs build for this PR succeeds (build latest to pull the new branch, then activate and
  build docs for new branch): https://readthedocs.org/projects/hdmf-common-schema/builds/

### After merging:
1. Create a new git tag. Pull the latest master branch locally, run `git tag [version] --sign`, copy and paste the
   release notes into the tag message, and run `git push --tags`.
2. On the [GitHub tags page](https://github.com/hdmf-dev/hdmf-common-schema/tags) page,
   click "..." -> "Create release" for the new tag on the right side of the page.
   Copy and paste the release notes into the release message, update the formatting if needed (reST to Markdown),
   and set the title to the version string.
3. Check that the readthedocs "latest" and "stable" builds run and succeed. Delete the readthedocs build for the
   merged PR. https://readthedocs.org/projects/hdmf-common-schema/builds/
4. Update the HDMF submodule in the HDMF branch corresponding to this schema version to point to the tagged commit.

See https://hdmf-common-schema.readthedocs.io/en/latest/software_process.html for more details.
