### PR TITLE
Fix minor formatting typo

### DIFF
--- a/docs/source/format_release_notes.rst
+++ b/docs/source/format_release_notes.rst
@@ -10,7 +10,7 @@ data types. Schema in the HDMF-experimental namespace are experimental and subje
 replaced by ``EnumData`` to provide more flexible support for data from a set of fixed values.
 
 - Added ``EnumData`` for storing data that comes from a set of fixed values. This replaces ``VocabData`` which could
-  hold only string values. Also, ``VocabData` could hold only a limited number of elements (~64k) when used with the
+  hold only string values. Also, ``VocabData`` could hold only a limited number of elements (~64k) when used with the
   HDF5 storage backend. ``EnumData`` gets around these restrictions by using an untyped dataset (VectorData) instead of
   a string attribute to hold the enumerated values.
 - Removed ``VocabData``.


### PR DESCRIPTION
## Summary of changes

- Minor fix in formatting of release notes. Does not require version bump or update to release note.

## PR checklist for schema changes

<!-- If the current schema version already ends in "-alpha", then delete the first two items: -->
- [ ] Update the version string in `docs/source/conf.py` and `common/namespace.yaml` to the next version with the suffix "-alpha"
- [ ] Add a new section in the release notes for the new version with the date "Upcoming"
- [ ] Add release notes for the PR to `docs/source/format_release_notes.rst`

<!-- See https://hdmf-common-schema.readthedocs.io/en/latest/software_process.html for more details. -->
