### PR TITLE
Update experimental namespace version and release notes

### DIFF
--- a/common/namespace.yaml
+++ b/common/namespace.yaml
@@ -46,4 +46,4 @@ namespaces:
   - doc: data types for storing references to web accessible resources
     source: resources.yaml
     title: Resource reference data types
-  version: 0.1.0
+  version: 0.2.0

--- a/docs/source/format_release_notes.rst
+++ b/docs/source/format_release_notes.rst
@@ -1,6 +1,13 @@
 hdmf-common Release Notes
 =========================
 
+??? (Upcoming)
+--------------
+- In the experimental ``ExternalResources``, added ``relative_path`` field to the "objects" table dtype. This is used in 
+  place of the previous ``field`` field representing the relative path to get to the dataset/attribute from the object. 
+  The previous ``field`` field will be used to represent a compound type field name if the dataset/attribute is a
+  compound dtype.
+
 1.5.0 (April 19, 2021)
 -------------------------
 - Added ``AlignedDynamicTable``, which defines a ``DynamicTable`` that supports storing a collection of sub-tables.

--- a/docs/source/format_release_notes.rst
+++ b/docs/source/format_release_notes.rst
@@ -7,6 +7,7 @@ hdmf-common Release Notes
   place of the previous ``field`` field representing the relative path to get to the dataset/attribute from the object. 
   The previous ``field`` field will be used to represent a compound type field name if the dataset/attribute is a
   compound dtype.
+- Update version of HDMF-experimental namespace from 0.1 to 0.2.
 
 1.5.0 (April 19, 2021)
 -------------------------


### PR DESCRIPTION
Update experimental namespace version from 0.1 to 0.2 and release notes. Because this is an update to the HDMF-experimental namespace, which is bundled with HDMF-common, and HDMF-common has not changed, this does not merit a release on the repo.
