### PR TITLE
Update dates for HDMF release

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,4 +21,3 @@ formats: all
 python:
   install:
     - requirements: requirements-doc.txt
-    - path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,9 +6,9 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: '3.9'
+    python: '3.12'
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: '3.9'
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  install:
+    - requirements: requirements-doc.txt
+    - path: .

--- a/Legal.txt
+++ b/Legal.txt
@@ -1,4 +1,4 @@
-“hdmf-common-schema” Copyright (c) 2019-2023, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
+“hdmf-common-schema” Copyright (c) 2019-2024, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
 
 If you have questions about your rights to use or distribute this software, please contact Berkeley Lab's Innovation & Partnerships Office at IPO@lbl.gov.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,7 +76,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'HDMF-common Specification'
-copyright = u'2019-2023, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.'
+copyright = u'2019-2024, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/license.txt
+++ b/license.txt
@@ -1,4 +1,4 @@
-“hdmf-common-schema” Copyright (c) 2019-2023, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
+“hdmf-common-schema” Copyright (c) 2019-2024, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 


### PR DESCRIPTION
## Summary of changes

- Update dates for hdmf release
- Add `.readthedocs.yaml` to build the docs. This was added to hdmf but was missed here.
## PR checklist for schema changes

<!-- If the current schema version already ends in "-alpha", then delete the first two items: -->
- [x] Update the version string in `docs/source/conf.py` and `common/namespace.yaml` to the next version with the suffix "-alpha"
- [x] Add a new section in the release notes for the new version with the date "Upcoming"
- [x] Add release notes for the PR to `docs/source/hdmf_common_release_notes.rst` and/or
  `docs/source/hdmf_experimental_release_notes.rst`

<!-- See https://hdmf-common-schema.readthedocs.io/en/latest/software_process.html for more details. -->
