### PR TITLE
Fix: GitHub workflow script injection

### DIFF
--- a/.github/workflows/hdmf_compatibility_schema.yml
+++ b/.github/workflows/hdmf_compatibility_schema.yml
@@ -2,6 +2,9 @@ name: Check HDMF Dev Compatibility
 
 on: [pull_request, workflow_dispatch]
 
+env:
+  HEAD_REF: ${{ github.head_ref }}
+
 jobs:
   check_compatibility:
     runs-on: ubuntu-latest
@@ -23,6 +26,6 @@ jobs:
           python -m pip install -r requirements-dev.txt -r requirements.txt
           python -m pip install -e .
           cd src/hdmf/common/hdmf-common-schema
-          git checkout ${{ github.head_ref }} # checkout branch
+          git checkout $HEAD_REF # checkout branch
           cd ../../../..
           pytest tests/unit/common/


### PR DESCRIPTION
Hi! I'm Joyce from Google's Open Source Security Team([GOSST](https://opensource.googleblog.com/2023/04/googles-open-source-security-upstream-team-one-year-later.html)) and I'm here to suggest this small fix to prevent from script injection attacks through your GitHub workflows.

You can see further explanation about this kind of threat in this blogpost [Keeping your GitHub Actions and workflows secure Part 2: Untrusted input](https://securitylab.github.com/resources/github-actions-untrusted-input/).

Any questions, let me know!

## Summary of changes

- parse `github.head_ref` to an envvar to prevent from potential script injection.

## PR checklist for schema changes

Not changing any schemas

<!-- If the current schema version already ends in "-alpha", then delete the first two items: -->
- [ ] Update the version string in `docs/source/conf.py` and `common/namespace.yaml` to the next version with the suffix "-alpha"
- [ ] Add a new section in the release notes for the new version with the date "Upcoming"
- [ ] Add release notes for the PR to `docs/source/hdmf_common_release_notes.rst` and/or
  `docs/source/hdmf_experimental_release_notes.rst`

<!-- See https://hdmf-common-schema.readthedocs.io/en/latest/software_process.html for more details. -->
