### PR TITLE
Change MeaningsTable.target from a link to an object-reference attribute

### DIFF
--- a/common/namespace.yaml
+++ b/common/namespace.yaml
@@ -26,7 +26,7 @@ namespaces:
   - doc: data types for storing references to web accessible resources
     source: resources.yaml
     title: Resource reference data types
-  version: 1.9.0
+  version: 1.10.0
 
 - name: hdmf-experimental
   doc: Experimental data structures provided by HDMF. These are not guaranteed to be available in the future.

--- a/common/table.yaml
+++ b/common/table.yaml
@@ -181,22 +181,24 @@ groups:
 
 - data_type_def: MeaningsTable
   data_type_inc: DynamicTable
-  doc: A table to store information about the meanings of values in a linked VectorData object.
-    All possible values of the linked VectorData object should be present in the 'value' column
+  doc: A table to store information about the meanings of values in a referenced VectorData object.
+    All possible values of the referenced VectorData object should be present in the 'value' column
     of this table, even if the value is not observed in the data. Additional columns may be
     added to store additional metadata about each value. The name of the MeaningsTable
-    should correspond to the name of the linked VectorData object with a "_meanings" suffix.
-    e.g., if the linked VectorData object is named "stimulus_type", the corresponding
+    should correspond to the name of the referenced VectorData object with a "_meanings" suffix.
+    e.g., if the referenced VectorData object is named "stimulus_type", the corresponding
     MeaningsTable should be named "stimulus_type_meanings".
   datasets:
   - name: value
     data_type_inc: VectorData
-    doc: The value of a row in the linked VectorData object.
+    doc: The value of a row in the referenced VectorData object.
   - name: meaning
     data_type_inc: VectorData
     dtype: text
-    doc: The meaning of the value in the linked VectorData object.
-  links:
+    doc: The meaning of the value in the referenced VectorData object.
+  attributes:
   - name: target
-    target_type: VectorData
-    doc: Link to the VectorData object for which this table provides meanings.
+    dtype:
+      target_type: VectorData
+      reftype: object
+    doc: Reference to the VectorData object for which this table provides meanings.

--- a/docs/source/hdmf_common_release_notes.rst
+++ b/docs/source/hdmf_common_release_notes.rst
@@ -3,6 +3,14 @@
 hdmf-common Release Notes
 =========================
 
+1.10.0 (Upcoming)
+-----------------
+- Changed ``MeaningsTable.target`` from a link to an object-reference attribute (``dtype`` with
+  ``reftype: object``, ``target_type: VectorData``). This matches ``VectorIndex.target`` and
+  ``DynamicTableRegion.table``, which use object references to point at a co-located dataset within
+  table machinery. This is a breaking change for files written with the 1.9.0 definition of
+  ``MeaningsTable``.
+
 1.9.0 (January 29, 2026)
 ------------------------
 - Changed the dtype of ``ElementIdentifiers`` and ``DynamicTableRegion`` from "int" to "int32". Under HDMF


### PR DESCRIPTION
## Summary

Changes `MeaningsTable.target` (common/table.yaml) from a **link** to an **object-reference attribute** (`dtype` with `reftype: object`, `target_type: VectorData`), matching `VectorIndex.target` and `DynamicTableRegion.table`.

```yaml
# before
links:
- name: target
  target_type: VectorData
  doc: Link to the VectorData object for which this table provides meanings.

# after
attributes:
- name: target
  dtype:
    target_type: VectorData
    reftype: object
  doc: Reference to the VectorData object for which this table provides meanings.
```

## Rationale

hdmf-common and nwb-schema use a consistent heuristic for the two mechanisms:

- **Link** points to a shared, standalone object owned elsewhere in the file, and possibly in another file since links can be external (e.g. `Device`, `ImagingPlane`, source `TimeSeries`).
- **Object-reference attribute/dtype** points to a co-located dataset from within table/column machinery (e.g. `VectorIndex.target`, `DynamicTableRegion.table`, `electrodes.group`, `ImageReferences`).

`MeaningsTable.target` is the second case: it points to a `VectorData` column of the same `DynamicTable` that owns the `meanings` group. The API in hdmf#1376 already enforces that the target must be a column of that table, so the target is inherently co-located and the link's only unique advantage, cross-file reach, does not apply. `VectorIndex.target` is the exact precedent: same target type, same name, same role of annotating a column of the same table, defined as an object reference.

The link in #91 was an unexamined default. The hdmf#1376 / #91 discussions were entirely about the `BaseDynamicTable` inheritance question; link vs. reference was never raised.

## Changes

- `common/table.yaml`: `MeaningsTable.target` link -> object-reference attribute; reconcile docstrings ("linked" -> "referenced").
- `common/namespace.yaml`: bump hdmf-common to `1.10.0`.
- `docs/source/hdmf_common_release_notes.rst`: add 1.10.0 entry.

## Notes for reviewers

- This is a **breaking change** to the 1.9.0 `MeaningsTable` definition. I bumped the version to `1.10.0`; adjust if you prefer a different number or want to fold it into a larger release. The release-notes date is left as "Upcoming".
- The corresponding API change in hdmf (hdmf/common/table.py) is not included here.

Verified the schema loads via HDMF 6.1.0 spec classes: `target` resolves to an attribute with dtype `{'target_type': 'VectorData', 'reftype': 'object'}` and `MeaningsTable.links` is empty.

## PR checklist for schema changes

- [x] Add release notes for the PR to `docs/source/hdmf_common_release_notes.rst`

🤖 Generated with [Claude Code](https://claude.com/claude-code)